### PR TITLE
Fix: device idx off-by-one error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,9 @@ fn make_device<P: AsRef<std::path::Path>>(
     let mut idx = DEVICE_INDEX_SEQ.lock().unwrap();
     let dev = evdev_rs::Device::new_from_path(path).context("failed to open device")?;
     let axes = get_input_axes(&dev, *idx);
+    let result = (*idx, dev, axes);
     *idx += 1;
-    Ok((*idx, dev, axes))
+    Ok(result)
 }
 
 fn run() -> Result<()> {


### PR DESCRIPTION
Increment of *idx before return caused device indices to be off by one during run, causing the JS host to ignore valid joystick events. This should resolve the issue described in #1. 